### PR TITLE
Fix: Remove redundant fields from config.json and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,14 +121,11 @@ The `config.json` file is used for non-sensitive configurations, such as the SMT
 
 ```json
 {
-  "email": "",
-  "email_password": "",
-  "bot_token": "",
   "smtp_server": "smtp.gmail.com",
   "smtp_port": 587
 }
 ```
-The `email`, `email_password`, and `bot_token` fields in `config.json` are placeholders and are overridden by the values in your `.env` file.
+The `config.json` file is for non-sensitive settings like the SMTP server and port. Sensitive credentials such as `email`, `email_password`, and `bot_token` are managed securely through the `.env` file and are not part of `config.json`.
 
 Save both files after making your changes.
 

--- a/config.json
+++ b/config.json
@@ -1,7 +1,4 @@
 {
-  "email": "",
-  "email_password": "",
-  "bot_token": "",
   "smtp_server": "smtp.gmail.com",
   "smtp_port": 587
 }


### PR DESCRIPTION
Removes the placeholder fields `email`, `email_password`, and `bot_token` from `config.json` as these are intended to be managed via the .env file.

The README.md has also been updated to reflect this change in the example `config.json` structure, reducing potential confusion for you during setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to clarify that sensitive credentials are no longer included in the configuration file and should be managed through environment variables.
- **Chores**
  - Simplified the configuration file by removing sensitive fields, retaining only non-sensitive settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->