### PR TITLE
I've refactored `setup_commands` to use `BotConfig` and addressed the…

### DIFF
--- a/bot_commands.py
+++ b/bot_commands.py
@@ -44,7 +44,7 @@ def setup_commands(bot: commands.Bot, config: BotConfig):
         Provides diagnostic information about the bot like uptime, server count, user count, and latency.
         """
         # Calculate uptime
-        uptime_seconds = time.time() - START_TIME # 'START_TIME' is from the setup_commands scope
+        uptime_seconds = time.time() - config.start_time # 'config' is the BotConfig instance from setup_commands
         days = int(uptime_seconds // (24 * 3600))
         hours = int((uptime_seconds % (24 * 3600)) // 3600)
         minutes = int((uptime_seconds % 3600) // 60)
@@ -59,7 +59,6 @@ def setup_commands(bot: commands.Bot, config: BotConfig):
                 user_count += guild.member_count
             except AttributeError: # member_count might not be available in some partial guild objects or due to intent issues
                 print(f"Warning: Could not retrieve member_count for guild {guild.id}. Ensure GUILD_MEMBERS intent is enabled if this is unexpected.")
-
 
         # Structure of the diagnostic message:
         # - Bot Ping (Latency)

--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ import dotenv # For loading environment variables from .env file
 
 # Local module imports
 from config_loader import load_config, load_email_template
-from bot_commands import setup_commands
+from bot_commands import setup_commands, BotConfig
 # Note: `email_utils` and `discord_ui` are internally used by `bot_commands.py`
 # and `discord_ui.py` respectively. They are not directly called from main.py after setup.
 
@@ -78,13 +78,16 @@ bot.temp_order_data: Dict = {}
 # This call passes the bot instance and necessary global configurations (loaded earlier)
 # to the command setup function, which then defines and registers the commands with the bot.
 print("Initializing and setting up slash commands...")
+bot_config_instance = BotConfig(
+    start_time=START_TIME,
+    sender_email=SENDER_EMAIL,
+    sender_password=SENDER_PASSWORD,
+    email_template=email_template,
+    app_config=config  # Use the existing 'config' as 'app_config'
+)
 setup_commands(
     bot,
-    START_TIME,
-    SENDER_EMAIL,
-    SENDER_PASSWORD,
-    email_template,
-    config
+    bot_config_instance
 )
 
 # --- Discord Bot Events ---


### PR DESCRIPTION
… email regex warning.

- I modified `main.py` to instantiate a `BotConfig` object and pass it to `bot_commands.setup_commands`. This resolves a TypeError where `setup_commands` was called with an incorrect number of arguments.
- I updated `bot_commands.py` to access `start_time` from the `BotConfig` object within the `run_diagnostics_command`.
- I confirmed that the `SyntaxWarning` related to `\.` in `email_utils.py` does not require a code change as the regex already uses a raw string. The warning may be environment-specific.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal configuration handling for improved maintainability. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->